### PR TITLE
Request unbreakable blocks as player loads chunks

### DIFF
--- a/src/main/java/com/github/labrynthmc/ClientModEventSubscriber.java
+++ b/src/main/java/com/github/labrynthmc/ClientModEventSubscriber.java
@@ -3,16 +3,20 @@ package com.github.labrynthmc;
 import com.github.labrynthmc.settings.MazeSizeMenuOption;
 import com.github.labrynthmc.structures.LightBlockPos;
 import com.github.labrynthmc.structures.UnbreakableBlocks;
+import com.github.labrynthmc.util.Utils;
 import net.minecraft.client.gui.IGuiEventListener;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.widget.button.Button;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.ChunkPos;
 import net.minecraftforge.client.event.GuiScreenEvent;
 import net.minecraftforge.event.entity.living.LivingEvent;
 import net.minecraftforge.event.entity.player.PlayerEvent;
+import net.minecraftforge.event.world.ChunkEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
+import sun.rmi.runtime.Log;
 
 import java.util.List;
 
@@ -105,6 +109,29 @@ public class ClientModEventSubscriber {
 				}
 			}
 		}
+	}
 
+	@SubscribeEvent
+	public void onChunkLoad(ChunkEvent.Load e) {
+		try {
+			if (!Utils.isNether(e.getWorld())) {
+				return;
+			}
+		} catch (NullPointerException npe) {
+			return;
+		}
+		ChunkPos pos = e.getChunk().getPos();
+		clientToServerHandler.apply(String.format("getUnbreakableBlocksChunk %d %d", pos.x, pos.z),
+				(s) -> {
+					String[] split = s.split(" ");
+					for (int i = 0; i < split.length - 2;) {
+						int x = Integer.parseInt(split[i++]);
+						int y = Integer.parseInt(split[i++]);
+						int z = Integer.parseInt(split[i++]);
+
+						UnbreakableBlocks.addUnbreakableBlock(new LightBlockPos(x, y, z));
+					}
+				}
+		);
 	}
 }

--- a/src/main/java/com/github/labrynthmc/util/ClientToServerHandler.java
+++ b/src/main/java/com/github/labrynthmc/util/ClientToServerHandler.java
@@ -3,17 +3,23 @@ package com.github.labrynthmc.util;
 import com.github.labrynthmc.Labrynth;
 import com.github.labrynthmc.structures.LightBlockPos;
 import com.github.labrynthmc.structures.UnbreakableBlocks;
+import net.minecraft.client.Minecraft;
 import net.minecraft.util.ResourceLocation;
-import net.minecraft.util.math.BlockPos;
 import net.minecraftforge.fml.network.NetworkDirection;
 import net.minecraftforge.fml.network.NetworkRegistry;
 import net.minecraftforge.fml.network.simple.SimpleChannel;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.StringWriter;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 import java.util.function.Consumer;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
 
 public class ClientToServerHandler {
 
@@ -30,19 +36,37 @@ public class ClientToServerHandler {
 		simpleChannel = NetworkRegistry.newSimpleChannel(
 			new ResourceLocation("labrynthmc", "clienttoserverhandler"),
 			() -> PROTOCOL_VERSION,
-			PROTOCOL_VERSION::equals,
+			PROTOCOL_VERSION::equals,//
 			PROTOCOL_VERSION::equals
 		);
 		simpleChannel.registerMessage(IDX, IntString.class,
 				(intString, packetBuffer) -> {
+					String toSend = intString.s;
+					byte[] toSendByte = null;
+					boolean isCompressed = false;
+					if (toSend.length() > 256) {
+						toSendByte = compress(intString.s);
+						isCompressed = toSendByte != null;
+					}
 					packetBuffer.writeInt(intString.id);
-					packetBuffer.writeString(intString.s);
 					packetBuffer.writeBoolean(intString.isResponse);
+					packetBuffer.writeBoolean(isCompressed);
+					if (isCompressed) {
+						packetBuffer.writeByteArray(toSendByte);
+					} else {
+						packetBuffer.writeString(toSend);
+					}
 				},
 				packetBuffer -> {
 					int id = packetBuffer.readInt();
-					String s = packetBuffer.readString(Integer.MAX_VALUE / 4);
 					boolean isResponse = packetBuffer.readBoolean();
+					boolean isCompressed = packetBuffer.readBoolean();
+					String s = "";
+					if (isCompressed) {
+						s = decompress(packetBuffer.readByteArray());
+					} else {
+						s = packetBuffer.readString(Integer.MAX_VALUE / 4);
+					}
 					return new IntString(id, s, isResponse);
 				},
 				(intString, contextSupplier) -> {
@@ -56,22 +80,33 @@ public class ClientToServerHandler {
 						simpleChannel.sendTo(new IntString(intString.id, handle(intString.s), true),
 								contextSupplier.get().getNetworkManager(), NetworkDirection.PLAY_TO_CLIENT);
 					}
+					contextSupplier.get().setPacketHandled(true);
 				}
 		);
 	}
 
-	public Future<String> apply(String s) {
-		IntString is = new IntString(idx++, s, false);
-		simpleChannel.sendToServer(is);
-		CompletableFuture<String> ret = new CompletableFuture<>();
-		futures.put(is.id, ret);
-		return ret;
+	public Future<String> applyForResult(String s) {
+		if (!hasConnection()) {
+			CompletableFuture<String> ret = new CompletableFuture<>();
+			ret.complete(handle(s));
+			return ret;
+		} else {
+			IntString is = new IntString(idx++, s, false);
+			CompletableFuture<String> ret = new CompletableFuture<>();
+			futures.put(is.id, ret);
+			simpleChannel.sendToServer(is);
+			return ret;
+		}
 	}
 
 	public void apply(String s, Consumer<String> consumer) {
-		IntString is = new IntString(idx++, s, false);
-		simpleChannel.sendToServer(is);
-		consumers.put(is.id, consumer);
+		if (!hasConnection()) {
+			consumer.accept(handle(s));
+		} else {
+			IntString is = new IntString(idx++, s, false);
+			simpleChannel.sendToServer(is);
+			consumers.put(is.id, consumer);
+		}
 	}
 
 	private static final String handle(String query) {
@@ -86,6 +121,24 @@ public class ClientToServerHandler {
 					int y = Integer.parseInt(split[2]);
 					int z = Integer.parseInt(split[3]);
 					return "" + !UnbreakableBlocks.getUnbreakableBlocks().contains(new LightBlockPos(x, y, z));
+				}
+				case "getUnbreakableBlocksChunk": {
+					int chunkX = Integer.parseInt(split[1]);
+					int chunkZ = Integer.parseInt(split[2]);
+					StringBuilder builder = new StringBuilder();
+					for (LightBlockPos pos : UnbreakableBlocks.getUnbreakableBlocks().getUnbreakableBlockSetInChunk(chunkX, chunkZ)) {
+						builder.append(String.format("%d %d %d ", pos.getX(), pos.getY(), pos.getZ()));
+					}
+					for (int x = chunkX << 4; x < (chunkX << 4) + 16; x++) {
+						for (int z = chunkZ << 4; z < (chunkZ << 4) + 16; z++) {
+							for (int y = 20; y < 45; y++) {
+								if (UnbreakableBlocks.getUnbreakableBlocks().contains(new LightBlockPos(x, y, z))) {
+									builder.append(String.format("%d %d %d ", x, y, z));
+								}
+							}
+						}
+					}
+					return builder.toString();
 				}
 			}
 		} catch (Throwable t) {
@@ -104,5 +157,43 @@ public class ClientToServerHandler {
 			this.s = s;
 			this.isResponse = isResponse;
 		}
+	}
+
+	private static byte[] compress(String s) {
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		GZIPOutputStream gout = null;
+		try {
+			gout = new GZIPOutputStream(out);
+			gout.write(s.getBytes());
+			gout.close();
+			return out.toByteArray();
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+		return null;
+	}
+
+	private static String decompress(byte[] bytes) {
+		try {
+			GZIPInputStream in = new GZIPInputStream(new ByteArrayInputStream(bytes));
+			StringWriter writer = new StringWriter();
+			byte[] buf = new byte[1024];
+			char[] charbuf = new char[1024];
+			int n;
+			while((n = in.read(buf)) != -1) {
+				for (int i = 0; i < n; i++) {
+					charbuf[i] = (char) buf[i];
+				}
+				writer.write(charbuf, 0, n);
+			}
+			return writer.toString();
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+		return "";
+	}
+
+	private static boolean hasConnection() {
+		return Minecraft.getInstance().getConnection() != null;
 	}
 }


### PR DESCRIPTION
When a player loads a chunk it requests the server to send the set of
unbreakable blocks. This change also reworks the implementation of the
UnbreakableBlockSet so it's quicker to get a set per chunk. This change
also attempts to compress large payloads when using the
ClientToServerHandler.